### PR TITLE
Update setup.py: protobuf < 3.20

### DIFF
--- a/cxr-foundation/setup.py
+++ b/cxr-foundation/setup.py
@@ -17,7 +17,7 @@ import setuptools
 
 setuptools.setup(
   name='cxr-foundation',
-  version='0.0.12',
+  version='0.0.13',
   description='CXR Foundation: chest x-ray embeddings generation.',
   install_requires=[
     'google-api-python-client',
@@ -31,7 +31,7 @@ setuptools.setup(
     'pypng',
     'pydicom',
     'tf-models-official >= 2.10.0',
-    'protobuf',
+    'protobuf <= 3.20',
     'typing-extensions',
     'shapely < 2.0.0'
   ],

--- a/cxr-foundation/setup.py
+++ b/cxr-foundation/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     'pypng',
     'pydicom',
     'tf-models-official >= 2.10.0',
-    'protobuf <= 3.20',
+    'protobuf < 3.20',
     'typing-extensions',
     'shapely < 2.0.0'
   ],


### PR DESCRIPTION
Even though 0.0.12 worked on Colab, when I tried to install it to a separate clean Linux machine, pip pulled in a newer protobuf version, which didn't work.
So, I'm explicitly limiting the protobuf version to < 3.20 to resolve that issue.