### PR TITLE
Add AUPRC as one of the metrics.

### DIFF
--- a/cxr-foundation/cxr_foundation/train_lib.py
+++ b/cxr-foundation/cxr_foundation/train_lib.py
@@ -165,5 +165,7 @@ def create_model(heads,
           learning_rate=learning_rate_fn),
       loss=dict([(head, 'binary_crossentropy') for head in heads]),
       loss_weights=loss_weights or dict([(head, 1.) for head in heads]),
-      weighted_metrics=['AUC'])
+      weighted_metrics=[
+        tf.keras.metrics.AUC(),
+        tf.keras.metrics.AUC(curve='PR', name='auc_pr')])
   return model


### PR DESCRIPTION
I did a quick test with this on the training step. Here is some example output:

```
Epoch 1/10
1/1 [==============================] - 3s 3s/step - loss: 0.7028 - auc: 0.6625 - auc_pr: 0.6283 - val_loss: 0.8958 - val_auc: 0.8333 - val_auc_pr: 0.8588
Epoch 2/10
1/1 [==============================] - 0s 44ms/step - loss: 0.6702 - auc: 0.6900 - auc_pr: 0.6519 - val_loss: 0.8847 - val_auc: 0.8750 - val_auc_pr: 0.9067
Epoch 3/10
1/1 [==============================] - 0s 40ms/step - loss: 0.6197 - auc: 0.7362 - auc_pr: 0.6985 - val_loss: 0.8738 - val_auc: 0.8750 - val_auc_pr: 0.9067
Epoch 4/10
1/1 [==============================] - 0s 40ms/step - loss: 0.5627 - auc: 0.7888 - auc_pr: 0.7588 - val_loss: 0.8621 - val_auc: 0.8750 - val_auc_pr: 0.9067
Epoch 5/10
1/1 [==============================] - 0s 42ms/step - loss: 0.5003 - auc: 0.8399 - auc_pr: 0.8237 - val_loss: 0.8496 - val_auc: 0.8750 - val_auc_pr: 0.9067
Epoch 6/10
1/1 [==============================] - 0s 40ms/step - loss: 0.4366 - auc: 0.8886 - auc_pr: 0.8885 - val_loss: 0.8380 - val_auc: 0.9167 - val_auc_pr: 0.9439
Epoch 7/10
1/1 [==============================] - 0s 44ms/step - loss: 0.3752 - auc: 0.9271 - auc_pr: 0.9285 - val_loss: 0.8255 - val_auc: 0.9167 - val_auc_pr: 0.9439
Epoch 8/10
1/1 [==============================] - 0s 42ms/step - loss: 0.3199 - auc: 0.9536 - auc_pr: 0.9566 - val_loss: 0.8112 - val_auc: 0.9167 - val_auc_pr: 0.9439
Epoch 9/10
1/1 [==============================] - 0s 41ms/step - loss: 0.2671 - auc: 0.9733 - auc_pr: 0.9752 - val_loss: 0.7961 - val_auc: 0.8750 - val_auc_pr: 0.9251
Epoch 10/10
1/1 [==============================] - 0s 43ms/step - loss: 0.2209 - auc: 0.9872 - auc_pr: 0.9876 - val_loss: 0.7776 - val_auc: 0.8958 - val_auc_pr: 0.9397
INFO:tensorflow:Assets written to: data/cxr-foundation-demo-outputs/model/assets
I0308 18:57:44.446171 140360281769792 builder_impl.py:779] Assets written to: data/cxr-foundation-demo-outputs/model/assets
```