### PR TITLE
Add --best_metrics and --best_metrics_mode to save the best model ckpt based on a chosen metrics

### DIFF
--- a/cxr-foundation/cxr_foundation/train.py
+++ b/cxr-foundation/cxr_foundation/train.py
@@ -77,6 +77,9 @@ flags.DEFINE_integer('batch_size', 512, 'The batch size for model training.')
 flags.DEFINE_integer('num_epochs', 300, 'The number of epochs to train.')
 
 flags.DEFINE_string('best_metrics', 'val_auc', 'The metrics used for saving the best model ckpt.')
+flags.DEFINE_string('best_metrics_mode', 'max',
+                    'The decision to overwrite the current save file is made based on either the '
+                    'maximization or the minimization of the monitored quantity.')
 
 FLAGS = flags.FLAGS
 
@@ -166,7 +169,7 @@ def train_model(
       filepath=save_model_name,
       save_weights_only=True,
       monitor=FLAGS.best_metrics,
-      mode='auto',
+      mode=FLAGS.best_metrics_mode,
       save_best_only=True,
       verbose=1)
 

--- a/cxr-foundation/cxr_foundation/train.py
+++ b/cxr-foundation/cxr_foundation/train.py
@@ -181,7 +181,7 @@ def train_model(
       epochs=num_epochs,
       callbacks=[model_checkpoint_callback],
   )
-  model.load_weights(save_model_name)
+  model = tf.keras.models.load_model(save_model_name)
   return model
 
 

--- a/cxr-foundation/cxr_foundation/train.py
+++ b/cxr-foundation/cxr_foundation/train.py
@@ -76,6 +76,8 @@ flags.DEFINE_string('save_model_name', '', 'The absolute or relative file name t
 flags.DEFINE_integer('batch_size', 512, 'The batch size for model training.')
 flags.DEFINE_integer('num_epochs', 300, 'The number of epochs to train.')
 
+flags.DEFINE_string('best_metrics', 'val_auc', 'The metrics used for saving the best model ckpt.')
+
 FLAGS = flags.FLAGS
 
 
@@ -96,9 +98,9 @@ def _main(_):
       train_label=FLAGS.train_label,
       validate_label=FLAGS.validate_label,
       batch_size=FLAGS.batch_size,
-      num_epochs=FLAGS.num_epochs)
+      num_epochs=FLAGS.num_epochs,
+      save_model_name=FLAGS.save_model_name)
 
-  model.save(FLAGS.save_model_name, include_optimizer=False)
   print(f"Saved trained model to file: {FLAGS.save_model_name}")
   
   return
@@ -113,6 +115,7 @@ def train_model(
     model: tf.keras.Model = None,
     batch_size: int = 512,
     num_epochs: int = 300,
+    save_model_name: str = None,
 ) -> tf.keras.Model:
   """Train a classification model from a set of .tfrecord image embeddings and their labels.
 
@@ -125,6 +128,7 @@ def train_model(
     model: The model to train. Defaults to the model from `train_lib.create_model` if none is specified. 
     batch_size: Batch size for training.
     num_epochs: Number of epochs to train.
+    save_model_name: Name for the model to save.
 
   The `df_labels` DataFrame must contain the follow columns with the specified headings:
   - "{head_name}" (equal to the `head_name` param): The label/outcome to train on.
@@ -158,12 +162,21 @@ def train_model(
         train_lib.get_dataset(file_names, labels=validate_labels).batch(1).cache()
     )
 
+  model_checkpoint_callback = tf.keras.callbacks.ModelCheckpoint(
+      filepath=save_model_name,
+      save_weights_only=True,
+      monitor=FLAGS.best_metrics,
+      mode='auto',
+      save_best_only=True,
+      verbose=1)
+
   # Get default model if none was specified
   model = model or train_lib.create_model([head_name])
   model.fit(
       x=training_data.batch(batch_size).prefetch(tf.data.AUTOTUNE).cache(),
       validation_data=validation_data,
       epochs=num_epochs,
+      callbacks=[model_checkpoint_callback],
   )
 
   return model

--- a/cxr-foundation/cxr_foundation/train.py
+++ b/cxr-foundation/cxr_foundation/train.py
@@ -182,7 +182,7 @@ def train_model(
       epochs=num_epochs,
       callbacks=[model_checkpoint_callback],
   )
-  model.load_model(save_model_name)
+  model.load_weights(save_model_name)
   return model
 
 

--- a/cxr-foundation/cxr_foundation/train.py
+++ b/cxr-foundation/cxr_foundation/train.py
@@ -104,6 +104,7 @@ def _main(_):
       num_epochs=FLAGS.num_epochs,
       save_model_name=FLAGS.save_model_name)
 
+  model.save(FLAGS.save_model_name, include_optimizer=False)
   print(f"Saved trained model to file: {FLAGS.save_model_name}")
   
   return
@@ -167,7 +168,7 @@ def train_model(
 
   model_checkpoint_callback = tf.keras.callbacks.ModelCheckpoint(
       filepath=save_model_name,
-      save_weights_only=False,
+      save_weights_only=True,
       monitor=FLAGS.best_metrics,
       mode=FLAGS.best_metrics_mode,
       save_best_only=True,
@@ -181,7 +182,7 @@ def train_model(
       epochs=num_epochs,
       callbacks=[model_checkpoint_callback],
   )
-  model = tf.keras.models.load_model(save_model_name)
+  model.load_model(save_model_name)
   return model
 
 

--- a/cxr-foundation/cxr_foundation/train.py
+++ b/cxr-foundation/cxr_foundation/train.py
@@ -167,7 +167,7 @@ def train_model(
 
   model_checkpoint_callback = tf.keras.callbacks.ModelCheckpoint(
       filepath=save_model_name,
-      save_weights_only=True,
+      save_weights_only=False,
       monitor=FLAGS.best_metrics,
       mode=FLAGS.best_metrics_mode,
       save_best_only=True,
@@ -181,7 +181,7 @@ def train_model(
       epochs=num_epochs,
       callbacks=[model_checkpoint_callback],
   )
-
+  model.load_weights(save_model_name)
   return model
 
 


### PR DESCRIPTION
The default --best_metrics is set to `val_auc`, and the default --best_metrics_mode is set to `max`.

I have a test run where I set `--best_metrics=val_auc_pr --best_metrics_mode=max`. Where I see the log like:

```
Epoch 21: val_auc_pr improved from 0.21084 to 0.21259, saving model to ./data/outputs/model
```

At the end of my run, I saw:

```
Epoch 100/100
1/1 [==============================] - ETA: 0s - loss: 4.8773e-05 - auc: 1.0000 - auc_pr: 1.0000
Epoch 100: val_auc_pr did not improve from 0.25706
1/1 [==============================] - 5s 5s/step - loss: 4.8773e-05 - auc: 1.0000 - auc_pr: 1.0000 - val_loss: 1.0718 - val_auc: 0.8833 - val_auc_pr: 0.2050
Saved trained model to file: ./data/outputs/model
```