### PR TITLE
Add TP,TN,FP,FN to metrics.

### DIFF
--- a/cxr-foundation/cxr_foundation/train_lib.py
+++ b/cxr-foundation/cxr_foundation/train_lib.py
@@ -170,6 +170,10 @@ def create_model(heads,
       loss=dict([(head, 'binary_crossentropy') for head in heads]),
       loss_weights=loss_weights or dict([(head, 1.) for head in heads]),
       weighted_metrics=[
+        tf.keras.metrics.FalsePositives(),
+        tf.keras.metrics.FalseNegatives(),
+        tf.keras.metrics.TruePositives(),
+        tf.keras.metrics.TrueNegatives(),
         tf.keras.metrics.AUC(),
         tf.keras.metrics.AUC(curve='PR', name='auc_pr')])
   return model


### PR DESCRIPTION
This can help users more easily interpret the counts of errors, especially on `val_` data.